### PR TITLE
Feedback

### DIFF
--- a/feedback/topdown-promille-def.R
+++ b/feedback/topdown-promille-def.R
@@ -1,0 +1,105 @@
+## hier aus didaktischen Gründen teilweise englische und deutsche Kommentare gemischt.
+## sie sollten englische Kommentare schreiben (in diesem Kurs & wann immer sie
+## vorhaben anderen Ihren Code zugänglich zu machen.)
+
+# computes approximate BAC (in per mille) at the end of the party (drinking_time[2])
+#
+# method:
+# https://web.archive.org/web/20150123143123/http://promille-rechner.org/erlaeuterung-der-promille-berechnung/
+# massn: 1l@6%; hoibe: 0.5l@6%; wein: 0.2l@11%; schnaps: 0.04l@40%
+#
+# inputs:
+#   age in years
+#   height in cm
+#   weight in kg
+#   drinking_time: sorted POSIXct vector giving start and end of the party
+#   drinks: list or vector with names "massn", "hoibe", "wein", "schnaps"
+#     counting the number consumed of each type of drink
+#  output:
+#    approximate BAC in per mille
+tell_me_how_drunk <- function(age, sex = c("male", "female"), height, weight,
+                              drinking_time, drinks) {
+  # inputs homogen machen:
+  drinks <- unlist(drinks)
+  sex <- tolower(sex)
+  # inputs checken:
+  checkmate::assert_number(age,
+                           lower = 10, upper = 110)
+  sex <- match.arg(sex)
+  checkmate::assert_number(height,
+                           lower = 100, upper = 230)
+  checkmate::assert_number(weight,
+                           lower = 40, upper = 300)
+  checkmate::assert_subset(names(drinks),
+                           choices = c("massn", "hoibe", "wein", "schnaps"),
+                           empty.ok = FALSE)
+  checkmate::assert_numeric(drinks,
+                            lower = 0, any.missing = FALSE, min.len = 1)
+  checkmate::assert_posixct(drinking_time,
+                            any.missing = FALSE, sorted = TRUE, len = 2)
+
+  # isTRUE weil drinks["schnaps"] NA ist wenn kein "schnaps"-Eintrag da ist.
+  illegal <- (age < 16 & sum(drinks) > 0) |
+             (age < 18 & isTRUE(drinks["schnaps"] > 0))
+  if (illegal) {
+    warning("\u2639 ...illegal!  \u2639")
+  }
+
+  alcohol_drunk <- get_alcohol(drinks)
+  bodywater <- get_bodywater(sex, age, height, weight)
+  max_permille <- get_permille(alcohol_drunk, bodywater)
+  sober_up(max_permille, drinking_time)
+}
+
+# compute consumed alcohol in g
+# massn, hoibe: 6%; wein: .2l@11%; schnaps: 4cl@40%
+get_alcohol <- function(drinks) {
+  # in ml
+  volume <- c(
+    "massn" = 1000,
+    "hoibe" = 500,
+    "wein" = 200,
+    "schnaps" = 40
+  )
+  # in volume-%
+  alcohol_concentration <- c(
+    "massn" = 0.06,
+    "hoibe" = 0.06,
+    "wein" = 0.11,
+    "schnaps" = 0.4
+  )
+  alcohol_density <- 0.8
+
+  # die indizierung mit names(drinks) erzeugt vektoren von volumen
+  # und alkoholgehalt die zu den einträgen in drinks passen
+  # (richtige reihenfolge & laenge):
+  sum(drinks * volume[names(drinks)] *
+        alcohol_concentration[names(drinks)] * alcohol_density)
+}
+
+# compute amount of water in a human body
+# coefficients from web-site promillerechner.org linked above
+get_bodywater <- function(sex = c("male", "female"), age, height, weight) {
+  coefficients <- switch(sex,
+                         "male"   = c(2.447, -0.09516, 0.1074, 0.3362),
+                         "female" = c(0.203, -0.07, 0.1069, 0.2466))
+ t(coefficients) %*% c(1, age, height, weight)
+}
+
+# compute max BAC (assumed: at drinking_time[1]...)
+get_permille <- function(alcohol_drunk, bodywater) {
+  alcohol_density <- 0.8
+  blood_density <- 1.055
+  permille <- alcohol_density * alcohol_drunk / (blood_density * bodywater)
+  permille
+}
+
+# compute BAC at drinking_time[2]
+sober_up <- function(permille, drinking_time) {
+  partylength <- difftime(drinking_time[2], drinking_time[1], units = "hours")
+  sober_per_hour <- 0.15
+  # abbau beginnt erst nach einer stunde:
+  depletion_duration <- max(0, partylength - 1)
+  # abbau kann nicht zu negativen promille führen:
+  max(0, permille - depletion_duration * sober_per_hour)
+}

--- a/feedback/topdown-promille-sol.Rmd
+++ b/feedback/topdown-promille-sol.Rmd
@@ -1,0 +1,12 @@
+```{r, child = "topdown-promille-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+Zum Beispiel so:
+```{r, def_promillerechner, code = readLines("topdown-promille-def.R"), echo=TRUE}
+```
+
+Die Fehlermeldungen könnte man hier sicher noch etwas informativer und allgemeinverständlicher machen indem man statt `checkmate::assert_XY` jeweils `if(<argument ungeeignet>) stop("<allgemeinverständliche Fehlermeldung>")` benutzt.  


### PR DESCRIPTION
@Eleftheria1 

recht gut, weiter so! :muscle:

topdown-design großteils erfolgreich gelöst, aber leider immer noch ein großer fehler in der funktionalität (s.u.).
input checks überzeugen mich nur teilweise


---------------------------------------------

Details:

- https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L8-L9
gut dass sie das hier kommentieren  :+1:  
vgl musterlösung für besser lesbarere variante  -- konstanten wie 0.8 mit aussagekräftigen namen belegen und dann die variable benutzen wäre besser finde ich.

- https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L18-L22
schlechte kapselung -- jede unterfunktion hat  EINE klar definierte aufgabe. das hier ist nicht teil der aufgabe dieser unterfunktion (alkoholmenge berechnen)

- https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L38  https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L40-L41 
hier überall besser `assert_number` -- `assert_integerish` ist überspezifisch (warum unbedingt ganze zahl?), `assert_numeric` ist für vektoren und nicht skalare.

- https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L44-L45
inkonsistente und überspezifische input checks -- wenn vektor übergeben muss er "integerish" sein (why? numeric wäre ausreichend!), wenn liste übergeben wird nur gecheckt dass liste mit höchstens 4 einträgen (why? `list(massn = 1, massn = 1, massn = 1, massn = 1, massn  =1)` wäre ja auch sinnvoller input und würde hier triggern, `list(bla = "blub", huhu = "haha")` dagegen nicht obwohl sinnlos)
https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L48-52 uff... viel  zu kompliziertes kompensieren des unvollständigen listen-checks davor... bessere strategie erst `unlist(drinks)`, dann vektor prüfen, vgl Musterlösung. wo immer möglich: inputs homogen machen statt mühsame fallunterscheidungen. hier tun sie so als könnten sie schon sicher sein dass auch in einer `drinks`-**liste** nur zahlen drinne stehen, das haben sie aber nie geprüft davor...
- https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L51 falsche, irreführende fehlermeldung und unvollständige prüfung, es dürfte erstens eh auch ein vektor sein und zweitens wissen sie hier noch gar nicht ob die elemente *integer* sind, das prüft die bedingung davor nicht ab, nur "jedes element in drinks positiv mit länge 1" ..... (sie müssten auch mMn eh nicht integer sein, aber wenn sie die fehlermeldung so schreiben dann müssen sie das auch so implementieren)

- https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L58-L60
hätte man auch noch einkapseln können/sollen, und sei es nur um mir zu demonstrieren dass sie das prinzip restlos durchdrungen haben... :smirk:


- https://github.com/fort-w2021/promille-ex-Eleftheria1/blob/26531f771fe019b752c68b11c86e4c30c5b51069/topdown-promille-ex-sol.Rmd#L59
BUG / INKORREKTE IMPLEMENTATION -- vgl Musterlösung
```r
── Failure (topdown-promille-tests.R:26:3): basic implementation is correct ────────────────────────────────────────────────
tell_me_how_drunk(...) not equivalent to 0.687.
1/1 mismatches
[1] 0.825 - 0.687 == 0.138
```

- benamung: `alc_conc`, `time_int`, `dens_blood` etc: das sind mir alles zu viele abrzngn, bitte abgewöhnen!